### PR TITLE
Append "exec" to java command

### DIFF
--- a/papermc.sh
+++ b/papermc.sh
@@ -31,4 +31,4 @@ if [ ! -e ${JAR_NAME} ]
 fi
 
 # Start server
-java -server -Xms${MC_RAM} -Xmx${MC_RAM} ${JAVA_OPTS} -jar ${JAR_NAME} nogui
+exec java -server -Xms${MC_RAM} -Xmx${MC_RAM} ${JAVA_OPTS} -jar ${JAR_NAME} nogui


### PR DESCRIPTION
PaperMC does not receive the SIGTERM signal from docker when attempting to stop the container. This causes docker to kill the container after 10 seconds and the server is not shut down gracefully. Adding "exec" causes the java command to become PID 1 instead of papermc.sh, then the SIGTERM signal is sent directly to java