### PR TITLE
Use quotes where appropriate and prefer bash [[

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
     && mkdir /papermc
 
 # Start script
-CMD ["sh", "./papermc.sh"]
+CMD ["bash", "./papermc.sh"]
 
 # Container setup
 EXPOSE 25565/tcp

--- a/papermc.sh
+++ b/papermc.sh
@@ -4,12 +4,12 @@
 cd papermc
 
 # Set nullstrings back to 'latest'
-: ${MC_VERSION:=latest}
-: ${PAPER_BUILD:=latest}
+: ${MC_VERSION:='latest'}
+: ${PAPER_BUILD:='latest'}
 
 # Lowercase these to avoid 404 errors on wget
-MC_VERSION=${MC_VERSION,,}
-PAPER_BUILD=${PAPER_BUILD,,}
+MC_VERSION="${MC_VERSION,,}"
+PAPER_BUILD="${PAPER_BUILD,,}"
 
 # Get version information and build download URL and jar name
 URL='https://papermc.io/api/v2/projects/paper'

--- a/papermc.sh
+++ b/papermc.sh
@@ -4,44 +4,44 @@
 cd papermc
 
 # Get version information and build download URL and jar name
-URL=https://papermc.io/api/v2/projects/paper
-if [ ${MC_VERSION} = latest ]
+URL='https://papermc.io/api/v2/projects/paper'
+if [[ $MC_VERSION == latest ]]
 then
   # Get the latest MC version
-  MC_VERSION=$(wget -qO - $URL | jq -r '.versions[-1]') # "-r" is needed because the output has quotes otherwise
+  MC_VERSION=$(wget -qO - "$URL" | jq -r '.versions[-1]') # "-r" is needed because the output has quotes otherwise
 fi
-URL=${URL}/versions/${MC_VERSION}
-if [ ${PAPER_BUILD} = latest ]
+URL="${URL}/versions/${MC_VERSION}"
+if [[ $PAPER_BUILD == latest ]]
 then
   # Get the latest build
-  PAPER_BUILD=$(wget -qO - $URL | jq '.builds[-1]')
+  PAPER_BUILD=$(wget -qO - "$URL" | jq '.builds[-1]')
 fi
-JAR_NAME=paper-${MC_VERSION}-${PAPER_BUILD}.jar
-URL=${URL}/builds/${PAPER_BUILD}/downloads/${JAR_NAME}
+JAR_NAME="paper-${MC_VERSION}-${PAPER_BUILD}.jar"
+URL="${URL}/builds/${PAPER_BUILD}/downloads/${JAR_NAME}"
 
 # Update if necessary
-if [ ! -e ${JAR_NAME} ]
+if [[ ! -e $JAR_NAME ]]
 then
   # Remove old server jar(s)
   rm -f *.jar
   # Download new server jar
-  wget ${URL} -O ${JAR_NAME}
+  wget "$URL" -O "$JAR_NAME"
   
   # If this is the first run, accept the EULA
-  if [ ! -e eula.txt ]
+  if [[ ! -e eula.txt ]]
   then
     # Run the server once to generate eula.txt
-    java -jar ${JAR_NAME}
+    java -jar "$JAR_NAME"
     # Edit eula.txt to accept the EULA
     sed -i 's/false/true/g' eula.txt
   fi
 fi
 
 # Add RAM options to Java options if necessary
-if [ ! -z "${MC_RAM}" ]
+if [[ -n $MC_RAM ]]
 then
-  JAVA_OPTS="-Xms${MC_RAM} -Xmx${MC_RAM} ${JAVA_OPTS}"
+  JAVA_OPTS="-Xms${MC_RAM} -Xmx${MC_RAM} $JAVA_OPTS"
 fi
 
 # Start server
-exec java -server ${JAVA_OPTS} -jar ${JAR_NAME} nogui
+exec java -server $JAVA_OPTS -jar "$JAR_NAME" nogui


### PR DESCRIPTION
[[ is a shell keyword, in which parameter expansion is not subject to
shell word-splitting, unlike in the built-in [ (or even /bin/[). It is
generally faster and more powerful, supports compound booleans, and
should be used everywhere [ would be, unless writing for #!/bin/sh.

Outside of [[ context, parameter expansion should be done within
double-quotes unless word-splitting is expected and desired, such as
$JAVA_OPTS in line 47.

Curly-braces around parameter expansion are not required anywhere in this
script, but was left in as a helpful visual delimiter in strings where
parameters and text are not separated by whitespace.