### PR TITLE
Change java version from 16 to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # JRE base
-FROM openjdk:16-slim
+FROM openjdk:17-slim
 
 # Environment variables
 ENV MC_VERSION="latest" \


### PR DESCRIPTION
The container automatically downloads the latest version of PaperMC (MC 1.18), which uses Java 17 instead of Java 16.

I updated the java version from openjdk-16 to openjdk-17 in the Dockerfile to meet this requirement.