### PR TITLE
Update Dockerfile to Java 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # JRE base
-FROM openjdk:16-slim
+FROM openjdk:18-slim
 
 # Environment variables
 ENV MC_VERSION="latest" \


### PR DESCRIPTION
Minecraft 1.18 requires at least Java 17.