### PR TITLE
Bump java base image version for Minecraft 1.18 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # JRE base
-FROM openjdk:16-slim
+FROM openjdk:17-slim
 
 # Environment variables
 ENV MC_VERSION="latest" \


### PR DESCRIPTION
Minecraft 1.18 requires a minimum Java version of 1.18.

I've tested this on my own server and the transition went smoothly. 