### PR TITLE
add libstdc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV MC_VERSION="latest" \
 
 COPY papermc.sh .
 RUN apk update \
+    && apk add libstdc++ \
     && apk add openjdk21-jre \
     && apk add bash \
     && apk add wget \


### PR DESCRIPTION
The paperMC server comes with spark preinstalled in the plugins folder. Running the server will cause spark to give an error saying libstdc++ is missing with a link to here:

https://spark.lucko.me/docs/misc/Using-async-profiler#install-libstdc

This change just adds libstdc++ in the dockerfile