### PR TITLE
patch: update to use new api endpoint

### DIFF
--- a/papermc.sh
+++ b/papermc.sh
@@ -12,7 +12,7 @@ MC_VERSION="${MC_VERSION,,}"
 PAPER_BUILD="${PAPER_BUILD,,}"
 
 # Get version information and build download URL and jar name
-URL='https://papermc.io/api/v2/projects/paper'
+URL='https://api.papermc.io/v2/projects/paper'
 if [[ $MC_VERSION == latest ]]
 then
   # Get the latest MC version


### PR DESCRIPTION
I've updated the endpoint to use `https://api.papermc.io`