### PR TITLE
feat: docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+
+services:
+  papermc:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: papermc
+    ports:
+      - "25565:25565/tcp"
+      - "25565:25565/udp"
+    environment:
+      MC_VERSION: "${MC_VERSION:-latest}"        
+      PAPER_BUILD: "${PAPER_BUILD:-latest}"     
+      EULA: "${EULA:-false}"                    
+      MC_RAM: "${MC_RAM:-}"                 
+      JAVA_OPTS: "${JAVA_OPTS:-}"              
+    volumes:
+      - ./papermc:/papermc
+    stdin_open: true        
+    tty: true


### PR DESCRIPTION

While setting up my server again, I created a docker compose file for my own server using your dockerfile. 

I have some other ideas in mind to implement on my own server- if one downloads the paper server .jar file on the server and place it in the directory- then the dockerfile will copy it to the container, if the bash script finds a .jar file then it uses that one- skipping the download from papermc.







Below is a brief documentation for Docker Compose, which can be included either in the main README.md file or in a separate 
.md file

## Docker compose

This is a simple setup for running a PaperMC Minecraft server using docker compose.
This docker Compose configuration stores a persistent volume alongside the server data in the specified directory. To switch to Docker's volume management, edit the docker-compose file, remove the relative path under volumes: `./papermc:/papermc` to `papermc:/papermc`

### Requirements

- Docker
- Docker Compose

### Setup

1. Generate a `.env` file with the following command: 
- `echo -e "MC_VERSION=latest\nPAPER_BUILD=latest\nEULA=true\nMC_RAM=2G\nJAVA_OPTS=" > .env`
- modify these values if needed

2. Run
- `docker-compose up -d`


### Docker Compose Commands

To build the server:
- `docker-compose build`

To run the server:
- `docker-compose up -d`

To stop the server:
- `docker-compose down`

### View the server logs:

To view the server logs, run one of the following commands:
- `docker logs <container-name> -f`
- `docker-compose logs -f` - requires you to go into the papermc directory
